### PR TITLE
fix test_device_linking on python 3.10

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -41,7 +41,7 @@ class PalgateAPI:
             response = await client.post(
                 urljoin(PalgateAPI._BASE_URL, f'secondary/init/{unique_id}'),
                 json={
-                    'secondary': str(TokenType.SECONDARY),  # FIXME this **OVERRIDES** secondary token!
+                    'secondary': str(TokenType.SECONDARY.value),  # FIXME this **OVERRIDES** secondary token!
                     'name': 'test',
                 },
                 headers=PalgateAPI._get_authenticated_headers(derived_token)


### PR DESCRIPTION
In python 3.10 `str(IntEnum.SOME_KEY)` returned a string "IntEnum.SOME_KEY" instead of expected string representation of SOME_KEY's value (this is the behavior in python > 3.10)