### PR TITLE
use repository secrets instead of environment secrets

### DIFF
--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   tests:
     name: 'Run Tests'
-    environment: production
     runs-on: ${{matrix.os}}
     strategy:
       matrix:


### PR DESCRIPTION
Apparently enviornment secrects are treated as "Depoyments". We don't want to treat tests as deployments